### PR TITLE
Remove quote from lambda for byte-compile warning

### DIFF
--- a/ant.el
+++ b/ant.el
@@ -37,7 +37,7 @@
                                                  ant-build-file-name))))
     (message output)
     (if (> (length output) 0)
-        (mapcar '(lambda (x) (replace-regexp-in-string ".*<target.*name=\"\\([^\-][^\"]*\\).*" "\\1" x)) 
+        (mapcar (lambda (x) (replace-regexp-in-string ".*<target.*name=\"\\([^\-][^\"]*\\).*" "\\1" x)) 
                 (split-string output "[\n]"))
       nil)))
 


### PR DESCRIPTION
This fixes following byte-compile warning.

```
In ant-find-tasks:
ant.el:41:31:Warning: (lambda (x) ...) quoted with ' rather than with #'
```
